### PR TITLE
Implement game setup from todo file

### DIFF
--- a/src/components/Lobby/Lobby.tsx
+++ b/src/components/Lobby/Lobby.tsx
@@ -320,7 +320,6 @@ export const Lobby = () => {
             <SearchDialog 
               lobbyId={lobbyId!}
               currentUserId={currentUserId}
-              isHost={isHost}
             />
             
             {/* My Songs for non-host players */}

--- a/src/components/MySongs/MySongs.tsx
+++ b/src/components/MySongs/MySongs.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
-import { subscribeTrackProposals } from '../../services/firebase';
-import type { TrackProposal } from '../../types/types';
+import { subscribeUserSongs } from '../../services/firebase';
+import type { Track } from '../../types/types';
 import './MySongs.css';
 
 interface MySongsProps {
@@ -9,19 +9,18 @@ interface MySongsProps {
 }
 
 export const MySongs = ({ lobbyId, userId }: MySongsProps) => {
-  const [proposals, setProposals] = useState<TrackProposal[]>([]);
+  const [tracks, setTracks] = useState<Track[]>([]);
   const [isExpanded, setIsExpanded] = useState(false);
 
   useEffect(() => {
-    const unsubscribe = subscribeTrackProposals(lobbyId, userId, (userProposals) => {
-      const myProposals = userProposals.filter(p => p.proposedBy === userId);
-      setProposals(myProposals);
+    const unsubscribe = subscribeUserSongs(lobbyId, userId, (userTracks) => {
+      setTracks(userTracks);
     });
 
     return unsubscribe;
   }, [lobbyId, userId]);
 
-  if (proposals.length === 0) {
+  if (tracks.length === 0) {
     return (
       <div className="my-songs empty">
         <div className="empty-state">
@@ -39,45 +38,11 @@ export const MySongs = ({ lobbyId, userId }: MySongsProps) => {
     return artists.map(artist => artist.name).join(', ');
   };
 
-  const getStatusIcon = (status: TrackProposal['status']) => {
-    switch (status) {
-      case 'approved':
-        return (
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" className="status-icon approved">
-            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
-          </svg>
-        );
-      case 'rejected':
-        return (
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" className="status-icon rejected">
-            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm3.59 5L12 10.59 8.41 7 7 8.41 10.59 12 7 15.59 8.41 17 12 13.41 15.59 17 17 15.59 13.41 12 17 8.41 15.59 7z"/>
-          </svg>
-        );
-      default:
-        return (
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" className="status-icon pending">
-            <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" opacity="0.3"/>
-          </svg>
-        );
-    }
-  };
-
-  const getStatusText = (status: TrackProposal['status']) => {
-    switch (status) {
-      case 'approved': return 'Added to playlist';
-      case 'rejected': return 'Not added';
-      default: return 'Pending';
-    }
-  };
-
   return (
     <div className="my-songs">
       <div className="my-songs-header" onClick={() => setIsExpanded(!isExpanded)}>
         <div className="header-content">
-          <h4 className="my-songs-title">My Songs ({proposals.length})</h4>
-          <div className="header-stats">
-            {proposals.filter(p => p.status === 'approved').length} added
-          </div>
+          <h4 className="my-songs-title">My Songs ({tracks.length})</h4>
         </div>
         <button className="expand-button" aria-label={isExpanded ? 'Collapse' : 'Expand'}>
           <svg 
@@ -94,13 +59,13 @@ export const MySongs = ({ lobbyId, userId }: MySongsProps) => {
 
       {isExpanded && (
         <div className="my-songs-list">
-          {proposals.map((proposal) => (
-            <div key={proposal.trackUri} className={`song-item ${proposal.status}`}>
+          {tracks.map((track) => (
+            <div key={track.uri} className="song-item">
               <div className="song-album">
-                {proposal.trackInfo.album.images[0] ? (
+                {track.album.images[0] ? (
                   <img
-                    src={proposal.trackInfo.album.images[0].url}
-                    alt={`${proposal.trackInfo.album.name} album cover`}
+                    src={track.album.images[0].url}
+                    alt={`${track.album.name} album cover`}
                     className="album-image"
                   />
                 ) : (
@@ -113,18 +78,15 @@ export const MySongs = ({ lobbyId, userId }: MySongsProps) => {
               </div>
 
               <div className="song-info">
-                <div className="song-name">{proposal.trackInfo.name}</div>
-                <div className="song-artist">{formatArtists(proposal.trackInfo.artists)}</div>
+                <div className="song-name">{track.name}</div>
+                <div className="song-artist">{formatArtists(track.artists)}</div>
               </div>
 
               <div className="song-status">
-                {getStatusIcon(proposal.status)}
-                <span className="status-text">{getStatusText(proposal.status)}</span>
-                {proposal.status === 'rejected' && proposal.reason && (
-                  <span className="rejection-reason" title={proposal.reason}>
-                    ({proposal.reason})
-                  </span>
-                )}
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" className="status-icon approved">
+                  <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+                </svg>
+                <span className="status-text">Added to playlist</span>
               </div>
             </div>
           ))}

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -431,6 +431,23 @@ export const addTrackProposal = async (
   });
 };
 
+export const subscribeUserSongs = (
+  lobbyId: string,
+  userId: string,
+  cb: (tracks: Track[]) => void,
+) => {
+  const ref = doc(db, 'playlists', lobbyId);
+  return onSnapshot(ref, snap => {
+    if (!snap.exists()) { cb([]); return; }
+    const songs = snap.data().songs ?? {};
+    cb(
+      Object.values(songs)
+        .filter((s: any) => s.addedBy === userId)
+        .map((s: any) => ({ ...s.trackInfo } as Track))
+    );
+  });
+};
+
 export const subscribeTrackProposals = (
   lobbyId: string, 
   userId: string, 


### PR DESCRIPTION
Implement direct song display in MySongs and update duplicate detection to fix song visibility and simplify the song addition flow.

The original system used a "track proposal" mechanism which caused songs to not appear immediately in "My Songs" after being added, as they were in a pending state. This PR refactors the system to directly add songs to the main playlist and display them, aligning with the simpler "OPTION A" described in `game_setup_todo.md`. This also ensures duplicate checks are against the actual playlist.

---

[Open in Web](https://cursor.com/agents?id=bc-f82218e9-38e6-4198-af7b-de004cd441d9) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-f82218e9-38e6-4198-af7b-de004cd441d9) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)