### PR TITLE
Disable adding already added songs in search

### DIFF
--- a/src/components/SearchDialog/SearchDialog.css
+++ b/src/components/SearchDialog/SearchDialog.css
@@ -85,11 +85,32 @@
   justify-content: space-between;
   padding: 1rem;
   border-bottom: 1px solid rgba(255, 255, 255, 0.05);
-  transition: background-color 0.2s ease;
+  transition: all 0.2s ease;
+  cursor: pointer;
+  position: relative;
 }
 
-.search-result-item:hover {
-  background: rgba(255, 255, 255, 0.05);
+.search-result-item:hover:not(.disabled) {
+  background: rgba(255, 255, 255, 0.08);
+  transform: translateX(4px);
+}
+
+.search-result-item:active:not(.disabled) {
+  transform: translateX(2px);
+}
+
+.search-result-item.disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.search-result-item.disabled:hover {
+  background: transparent;
+  transform: none;
+}
+
+.search-result-item.already-added:not(.disabled) {
+  background: rgba(29, 185, 84, 0.05);
 }
 
 .search-result-item:last-child {
@@ -153,7 +174,7 @@
 .track-actions {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.75rem;
   flex-shrink: 0;
 }
 
@@ -178,6 +199,23 @@
 .preview-btn:hover {
   background: rgba(255, 255, 255, 0.2);
   transform: scale(1.05);
+}
+
+.add-icon {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #1db954 0%, #1ed760 100%);
+  border-radius: 8px;
+  color: white;
+  transition: all 0.2s ease;
+}
+
+.search-result-item:hover:not(.disabled) .add-icon {
+  transform: scale(1.1);
+  box-shadow: 0 4px 12px rgba(29, 185, 84, 0.3);
 }
 
 .add-btn {
@@ -270,6 +308,32 @@
   animation: spin 1s linear infinite;
 }
 
+.track-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.track-status.added-by-user {
+  background: rgba(29, 185, 84, 0.1);
+  color: #4ade80;
+  border: 1px solid rgba(29, 185, 84, 0.2);
+}
+
+.track-status.added-by-other {
+  background: rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.track-status svg {
+  flex-shrink: 0;
+}
+
 @keyframes spin {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
@@ -285,10 +349,17 @@
     flex-direction: column;
     align-items: flex-start;
     gap: 1rem;
+    padding: 0.75rem;
+  }
+  
+  .search-result-item:hover:not(.disabled) {
+    transform: none;
   }
   
   .track-actions {
     align-self: flex-end;
+    width: 100%;
+    justify-content: flex-end;
   }
   
   .proposal-item {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement real-time updates for song search results to prevent users from adding songs already added by others and improve the UI/UX.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The entire song row is now clickable to add a song, and songs added by other users are clearly greyed out with a status indicator, providing immediate visual feedback and a smoother user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-62c887c1-7768-4ac8-819c-12fab181e75a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-62c887c1-7768-4ac8-819c-12fab181e75a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>